### PR TITLE
Removed redundant check for lineThickness > 0

### DIFF
--- a/Greenshot/Drawing/ArrowContainer.cs
+++ b/Greenshot/Drawing/ArrowContainer.cs
@@ -61,33 +61,31 @@ namespace Greenshot.Drawing {
 				graphics.PixelOffsetMode = PixelOffsetMode.None;
 				Color lineColor = GetFieldValueAsColor(FieldType.LINE_COLOR);
 				ArrowHeadCombination heads = (ArrowHeadCombination)GetFieldValue(FieldType.ARROWHEADS);
-				if (lineThickness > 0) {
-					if (shadow) {
-						//draw shadow first
-						int basealpha = 100;
-						int alpha = basealpha;
-						int steps = 5;
-						int currentStep = 1;
-						while (currentStep <= steps) {
-							using (Pen shadowCapPen = new Pen(Color.FromArgb(alpha, 100, 100, 100), lineThickness)) {
-								SetArrowHeads(heads, shadowCapPen);
+				if (shadow) {
+					//draw shadow first
+					int basealpha = 100;
+					int alpha = basealpha;
+					int steps = 5;
+					int currentStep = 1;
+					while (currentStep <= steps) {
+						using (Pen shadowCapPen = new Pen(Color.FromArgb(alpha, 100, 100, 100), lineThickness)) {
+							SetArrowHeads(heads, shadowCapPen);
 
-								graphics.DrawLine(shadowCapPen,
-									Left + currentStep,
-									Top + currentStep,
-									Left + currentStep + Width,
-									Top + currentStep + Height);
+							graphics.DrawLine(shadowCapPen,
+								Left + currentStep,
+								Top + currentStep,
+								Left + currentStep + Width,
+								Top + currentStep + Height);
 
-								currentStep++;
-								alpha = alpha - basealpha / steps;
-							}
+							currentStep++;
+							alpha = alpha - basealpha / steps;
 						}
+					}
 
-					}
-					using (Pen pen = new Pen(lineColor, lineThickness)) {
-						SetArrowHeads(heads, pen);
-						graphics.DrawLine(pen, Left, Top, Left + Width, Top + Height);
-					}
+				}
+				using (Pen pen = new Pen(lineColor, lineThickness)) {
+					SetArrowHeads(heads, pen);
+					graphics.DrawLine(pen, Left, Top, Left + Width, Top + Height);
 				}
 			}
 		}


### PR DESCRIPTION
There was an additional check for lineThickness > 0 before checking if shadow is true and drawing. We already know that lineThickess is greater than zero due to the check at line 57